### PR TITLE
Fix restore bug, and sort restoreable backups by mtime

### DIFF
--- a/mdbtool/plugins/mysqldump/Restore.py
+++ b/mdbtool/plugins/mysqldump/Restore.py
@@ -138,7 +138,7 @@ class Restorer:
             begining.extend([
                 '7zr e -so',
                 fullpath,
-                '2 > /dev/null'
+                '2>/dev/null'
                 '|'
             ])
         else:


### PR DESCRIPTION
Hi @zeenlym 

I have found and fixed a bug in the restore functionality. The way you were constructing the `2>/dev/null` shell redirection was not working, as it must be `2>wherever` and not (as you had) `2 > wherever`. Your command resulted in passing a '2' argument to `7zr` which caused it to try to extract a file called '2' which does not exist in the archive.

~~I have also added some (not very well tested) code to sort the list of backups available to restore by file modification time, this makes it easier to select the correct one.~~

Can you merge this into master and rebuild the docker image on docker hub please?